### PR TITLE
added in options

### DIFF
--- a/cachelib/allocator/DynamicFreeThresholdStrategy.h
+++ b/cachelib/allocator/DynamicFreeThresholdStrategy.h
@@ -31,7 +31,7 @@ namespace cachelib {
 class DynamicFreeThresholdStrategy : public BackgroundEvictorStrategy {
 
 public:
-  DynamicFreeThresholdStrategy(double lowEvictionAcWatermark, double highEvictionAcWatermark, uint64_t maxEvictionBatch, uint64_t minEvictionBatch);
+  DynamicFreeThresholdStrategy(double lowEvictionAcWatermark, double highEvictionAcWatermark, uint64_t maxEvictionBatch, uint64_t minEvictionBatch, double highEvictionDelta);
   ~DynamicFreeThresholdStrategy() {}
 
   std::vector<size_t> calculateBatchSizes(const CacheBase& cache, std::vector<std::tuple<TierId, PoolId, ClassId>> acVecs);

--- a/cachelib/allocator/FreeThresholdStrategy.cpp
+++ b/cachelib/allocator/FreeThresholdStrategy.cpp
@@ -43,7 +43,6 @@ std::vector<size_t> FreeThresholdStrategy::calculateBatchSizes(
   if (batches.size() == 0) {
     return batches;
   }
-  /*
   auto maxBatch = *std::max_element(batches.begin(), batches.end());
   if (maxBatch == 0)
     return batches;
@@ -59,7 +58,6 @@ std::vector<size_t> FreeThresholdStrategy::calculateBatchSizes(
     else
       return cappedBatchSize;
   });
-  */
   return batches;
 }
 

--- a/cachelib/cachebench/test_configs/simple_tiers_test.json
+++ b/cachelib/cachebench/test_configs/simple_tiers_test.json
@@ -1,36 +1,40 @@
 // @nolint instantiates a small cache and runs a quick run of basic operations.
 {
   "cache_config" : {
-    "cacheSizeMB" : 512,
+    "cacheSizeMB" : 1024,
     "usePosixShm" : true,
     "persistedCacheDir" : "/tmp/mem-tiers",
     "memoryTiers" : [
       {
         "ratio": 1,
         "file": "/tmp/mem-tiers/memory-mapped-tier"
+      },
+      {
+        "ratio": 1,
+        "file": "/tmp/mem-tiers/memory-mapped-tier2"
       }
-    ],
-    "poolRebalanceIntervalSec" : 1,
-    "moveOnSlabRelease" : false,
 
-    "numPools" : 2,
-    "poolSizes" : [0.3, 0.7]
+    ],
+    "backgroundEvictorIntervalMilSec": 10,
+    "backgroundPromoterIntervalMilSec": 0,
+    "backgroundManagerIntervalSec": 10,
+    "promoterThreads": 0,
+    "evictorThreads": 2
+
   },
   "test_config" : {
-      "numOps" : 100000,
-      "numThreads" : 32,
-      "numKeys" : 1000000,
+      "numOps" : 1000000,
+      "numThreads" : 8,
+      "numKeys" : 400000,
 
       "keySizeRange" : [1, 8, 64],
       "keySizeRangeProbability" : [0.3, 0.7],
 
-      "valSizeRange" : [1, 32, 10240, 409200],
-      "valSizeRangeProbability" : [0.1, 0.2, 0.7],
+      "valSizeRange" : [100, 1000, 10240, 40920, 80000],
+      "valSizeRangeProbability" : [0.2, 0.3, 0.2, 0.3],
+      "enableLookaside": true,
+      "getRatio" : 0.85,
+      "setRatio" : 0.15
 
-      "getRatio" : 0.15,
-      "setRatio" : 0.8,
-      "delRatio" : 0.05,
-      "keyPoolDistribution": [0.4, 0.6],
-      "opPoolDistribution" : [0.5, 0.5]
   }
 }

--- a/cachelib/cachebench/test_configs/simple_tiers_test_policy.json
+++ b/cachelib/cachebench/test_configs/simple_tiers_test_policy.json
@@ -1,0 +1,43 @@
+// @nolint instantiates a small cache and runs a quick run of basic operations.
+{
+  "cache_config" : {
+    "cacheSizeMB" : 1024,
+    "usePosixShm" : true,
+    "persistedCacheDir" : "/tmp/mem-tiers",
+    "memoryTiers" : [
+      {
+        "ratio": 1,
+        "file": "/tmp/mem-tiers/memory-mapped-tier"
+      },
+      {
+        "ratio": 1,
+        "file": "/tmp/mem-tiers/memory-mapped-tier2"
+      }
+
+    ],
+    "backgroundEvictorIntervalMilSec": 10,
+    "backgroundPromoterIntervalMilSec": 0,
+    "backgroundEvictorStrategy": "",
+    "highEvictionDelta": 0.1,
+    "lowEvictionAcWatermark": 1,
+    "highEvictionAcWatermark": 3,
+    "promoterThreads": 0,
+    "evictorThreads": 2
+
+  },
+  "test_config" : {
+      "numOps" : 1000000,
+      "numThreads" : 8,
+      "numKeys" : 400000,
+
+      "keySizeRange" : [1, 8, 64],
+      "keySizeRangeProbability" : [0.3, 0.7],
+
+      "valSizeRange" : [100, 1000, 10240, 40920, 80000],
+      "valSizeRangeProbability" : [0.2, 0.3, 0.2, 0.3],
+      "enableLookaside": true,
+      "getRatio" : 0.85,
+      "setRatio" : 0.15
+
+  }
+}

--- a/cachelib/cachebench/util/CacheConfig.h
+++ b/cachelib/cachebench/util/CacheConfig.h
@@ -293,6 +293,7 @@ struct CacheConfig : public JSONConfig {
 
   bool disableEvictionToMemory{false};
 
+  double highEvictionDelta{0.5}; 
   double promotionAcWatermark{4.0};
   double lowEvictionAcWatermark{2.0};
   double highEvictionAcWatermark{5.0};


### PR DESCRIPTION
See simple_tiers_test_policy.json for options, if you put backgroundEvictorStrategy: "dynamic" it will enable the dynamic threshold policy. if you leave it empty the default policy will run.

I also put the batch size cap back in as we can use `maxEvictionBatch` to control batch size` (can set to 1000000) for unlimited if needed.